### PR TITLE
Add optional `onResize` callback that can be defined by the user

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,13 @@ var componentWidthMixin = require('react-component-width-mixin');
 
 React.createClass({
   mixins: [componentWidthMixin],
-  
+
+  onResize: function() {
+    // Optional hook/callback function. Called each time the element is resized.
+    // onResize will also be called when the element is instantiated and has
+    // its componentWidth set for the first time.
+  },
+
   render: function() {
     // Now the component width is available after the initial render
     // as this.state.componentWidth.

--- a/index.js
+++ b/index.js
@@ -15,18 +15,19 @@ module.exports = {
   componentDidMount: function() {
     this.setState({
       componentWidth: ReactDOM.findDOMNode(this).getBoundingClientRect().width
-    });
-    elementResizeEvent(ReactDOM.findDOMNode(this), this.onResize);
+    }, this.onResize);
+    elementResizeEvent(ReactDOM.findDOMNode(this), this._onResize);
   },
   // When the DOM updates, check that our resize sensor is still there.
   componentDidUpdate: function() {
     if (0 === ReactDOM.findDOMNode(this).getElementsByClassName('resize-sensor').length) {
-      elementResizeEvent(ReactDOM.findDOMNode(this), this.onResize);
+      elementResizeEvent(ReactDOM.findDOMNode(this), this._onResize);
     }
   },
-  onResize: function() {
+  _onResize: function() {
+    // Update the componentWidth and call this.onResize (if it was defined).
     this.setState({
       componentWidth: ReactDOM.findDOMNode(this).getBoundingClientRect().width
-    });
+    }, this.onResize);
   }
 };


### PR DESCRIPTION
Great lib you have, it works in a quite clever way on its core.

I'm just adding a functionality that I'll be needing soon.

modified `README.md`'s example should explain how it should work.

``` javascript
var componentWidthMixin = require('react-component-width-mixin');

React.createClass({
  mixins: [componentWidthMixin],

  onResize: function() {
    // Optional hook/callback function. Called each time the element is resized.
    // onResize will also be called when the element is instantiated and has
    // its componentWidth set for the first time.
  },

  render: function() {
    // Now the component width is available after the initial render
    // as this.state.componentWidth.
  }
});
```

Cheers!
